### PR TITLE
Allow installation with league/flysystem 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "bower-asset/jquery": ">=2.2",
-        "league/flysystem": "^2.0",
+        "league/flysystem": "^2.0 || ^3.0",
         "yiisoft/yii2": "~2.0.13"
     },
     "license": "MIT",


### PR DESCRIPTION
There seem to be no breaking changes between 2.x and 3.x for this use case (they claim there's only BC for Adapter implementations).

> Since V2, V3 has been released which is backwards compatible from a consumption point of view, but it has a BC break for custom adapter implementations.

See: https://flysystem.thephpleague.com/docs/what-is-new/

Tested it on my own site, works fine with `league/flysystem` 3.15.1 and `league/flysystem-aws-s3-v3` 3.15.0.